### PR TITLE
Add trading workflow with basic nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # bot
+
+## Trading Workflow
+
+The `trading_workflow.json` file contains a simple example of an n8n workflow for a trading bot. The workflow is split into three nodes that illustrate the core logic:
+
+1. **Market Data** – An `HTTP Request` node that queries an exchange API for the latest ticker information.
+2. **Trading Condition** – An `IF` node that checks whether the returned price meets a predefined target. This represents the decision logic, which can be as simple or complex as needed.
+3. **Notification** – An `Email` node that notifies you whenever the condition is met. It shows how to integrate alerts after processing the data.
+
+This basic workflow highlights a straightforward setup. More advanced strategies could chain additional nodes for order execution or multiple conditions.

--- a/trading_workflow.json
+++ b/trading_workflow.json
@@ -1,0 +1,50 @@
+{
+  "name": "Trading Workflow",
+  "nodes": [
+    {
+      "name": "Market Data",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-200, 0],
+      "parameters": {
+        "url": "https://api.exchange.example/ticker",
+        "responseFormat": "json"
+      }
+    },
+    {
+      "name": "Trading Condition",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [0, 0],
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{ $json[\"price\"] }}",
+              "operation": "larger",
+              "value2": 1000
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Notification",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [200, 0],
+      "parameters": {
+        "subject": "Trading Alert",
+        "text": "Price target reached."
+      }
+    }
+  ],
+  "connections": {
+    "Market Data": {
+      "main": [[{ "node": "Trading Condition", "type": "main", "index": 0 }]]
+    },
+    "Trading Condition": {
+      "main": [[{ "node": "Notification", "type": "main", "index": 0 }]]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document a new trading workflow
- create `trading_workflow.json` describing nodes for market data, condition checking, and notification

## Testing
- `jq . trading_workflow.json >/tmp/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_685eb1b48d9c832c85f122f75ddd8630