### PR TITLE
Add trading bot example with Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,23 @@ La réponse contiendra l'identifiant et l'URL raccourcie retournés par le workf
 - Une base Airtable contenant la table que vous souhaitez utiliser pour stocker les liens.
 - Facultatif : configurez la variable d'environnement `WEBHOOK_URL` de n8n si vous utilisez un domaine personnalisé.
 
+
+## Bot de trading
+
+Ce dépôt propose également un exemple de **bot de trading** écrit en Python (`trading_bot.py`).
+Il s'agit d'une ébauche reposant sur la librairie `yfinance` pour récupérer les cours
+boursiers en temps réel. Le programme analyse les données à l'aide d'une stratégie
+simple de croisements de moyennes mobiles pour générer des signaux **BUY** ou **SELL**.
+Chaque signal déclenche l'envoi d'une notification (fonctionalité à personnaliser
+selon vos besoins).
+
+Pour l'exécuter :
+
+```bash
+pip install -r requirements.txt
+python trading_bot.py
+```
+
+Le bot télécharge les cours de l'action `AAPL` toutes les minutes et affiche les
+signaux détectés. Vous pouvez adapter la logique d'analyse et les notifications en
+modifiant le fichier `trading_bot.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+yfinance
+pandas
+matplotlib

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,0 +1,67 @@
+import asyncio
+from typing import List
+
+import pandas as pd
+import yfinance as yf
+import matplotlib.pyplot as plt
+
+# Simple trading bot skeleton using moving average crossover strategy
+# Fetches data periodically and notifies on signals
+
+class TradingBot:
+    def __init__(self, symbol: str, short_window: int = 20, long_window: int = 50):
+        self.symbol = symbol
+        self.short_window = short_window
+        self.long_window = long_window
+        self.prices = pd.DataFrame()
+
+    async def fetch_price(self) -> None:
+        ticker = yf.Ticker(self.symbol)
+        data = ticker.history(period="1d", interval="1m")
+        if not data.empty:
+            self.prices = data
+
+    def analyze(self) -> List[str]:
+        signals = []
+        if self.prices.empty:
+            return signals
+        df = self.prices.copy()
+        df["short_ma"] = df["Close"].rolling(window=self.short_window).mean()
+        df["long_ma"] = df["Close"].rolling(window=self.long_window).mean()
+        if len(df) < self.long_window:
+            return signals
+        if df["short_ma"].iloc[-2] <= df["long_ma"].iloc[-2] and df["short_ma"].iloc[-1] > df["long_ma"].iloc[-1]:
+            signals.append("BUY")
+        if df["short_ma"].iloc[-2] >= df["long_ma"].iloc[-2] and df["short_ma"].iloc[-1] < df["long_ma"].iloc[-1]:
+            signals.append("SELL")
+        return signals
+
+    def plot(self) -> None:
+        if self.prices.empty:
+            return
+        df = self.prices
+        plt.figure(figsize=(10, 5))
+        plt.plot(df.index, df["Close"], label="Close")
+        plt.plot(df.index, df["Close"].rolling(window=self.short_window).mean(), label=f"MA{self.short_window}")
+        plt.plot(df.index, df["Close"].rolling(window=self.long_window).mean(), label=f"MA{self.long_window}")
+        plt.legend()
+        plt.show()
+
+    async def send_notification(self, message: str) -> None:
+        # Placeholder for notification logic (email, SMS, etc.)
+        print(f"Notification: {message}")
+
+    async def run(self) -> None:
+        while True:
+            await self.fetch_price()
+            signals = self.analyze()
+            for signal in signals:
+                await self.send_notification(f"{signal} signal for {self.symbol}")
+            await asyncio.sleep(60)
+
+if __name__ == "__main__":
+    bot = TradingBot("AAPL")
+    try:
+        asyncio.run(bot.run())
+    except KeyboardInterrupt:
+        print("Stopping bot")


### PR DESCRIPTION
## Summary
- add `trading_bot.py` implementing a simple moving average trading example
- add `requirements.txt` listing dependencies
- document the bot in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686135d0ce20832cbd8066f75d0abf18